### PR TITLE
Updates to boto to support EC2 IAM roles (security tokens)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM stackbrew/ubuntu:precise
 RUN apt-get update
 RUN apt-get install -y python-requests python-boto
 
-ADD bin/elb-presence /bin/elb-presence
+ADD elb-presence /bin/elb-presence
 
 CMD /bin/elb-presence

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM stackbrew/ubuntu:precise
 
 RUN apt-get update
-RUN apt-get install -y python-requests python-boto
+RUN apt-get install -y python-requests python-pip && pip install --upgrade boto
 
 ADD elb-presence /bin/elb-presence
 

--- a/elb-presence
+++ b/elb-presence
@@ -16,11 +16,13 @@ parser.add_argument('--region', metavar='<REGION>', default=os.environ.get('AWS_
                     help='AWS region in which the ELB resides')
 parser.add_argument('--access-key', metavar='<ACCESS>', default=os.environ.get('AWS_ACCESS_KEY'))
 parser.add_argument('--secret-key', metavar='<SECRET>', default=os.environ.get('AWS_SECRET_KEY'))
+parser.add_argument('--security-token', metavar='<TOKEN>', default=os.environ.get('AWS_TOKEN'))
 args = parser.parse_args()
 
 conn = boto.ec2.elb.connect_to_region(args.region,
                                       aws_access_key_id=args.access_key,
-                                      aws_secret_access_key=args.secret_key)
+                                      aws_secret_access_key=args.secret_key,
+                                      security_token=args.security_token)
 
 instance = requests.get("http://169.254.169.254/latest/meta-data/instance-id").content
 

--- a/elb-presence
+++ b/elb-presence
@@ -22,7 +22,7 @@ args = parser.parse_args()
 conn = boto.ec2.elb.connect_to_region(args.region,
                                       aws_access_key_id=args.access_key,
                                       aws_secret_access_key=args.secret_key,
-                                      security_token=args.security_token)
+                                      security_token=args.security_token or None)
 
 instance = requests.get("http://169.254.169.254/latest/meta-data/instance-id").content
 


### PR DESCRIPTION
EC2 roles are a much more secure way to assign keys and secrets to an instance, and I've updated the elb-presence to support this. Not sure what happens in the case where plain old access keys are used, as I don't use these anywhere in my environment.