### PR TITLE
fix: make sure elb-presence stays pid 1 inside the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ RUN apt-get install -y python-boto
 
 ADD elb-presence /bin/elb-presence
 
-CMD /bin/elb-presence
+CMD ["/bin/elb-presence"]


### PR DESCRIPTION
When the `CMD /bin/elb-presence` syntax is used, it gets converted to `/bin/sh -c /bin/elb-presence`.  

As a result, inside the container, `/bin/sh` is pid 1, and `/usr/bin/python /bin/elb-presence` is a child process of `/bin/sh`.  This seems to have been interfering with the `SIGTERM` sent by `docker stop`, preventing the signal handler from ever de-registering the instance in question from its ELB.

Once the `Dockerfile` was changed to use the `CMD ["/bin/elb-presence"]` syntax as per this commit, the only process in the container was `/usr/bin/python /bin/elb-presence`, and the de-registration handler started working as expected.