### PR TITLE
Feature/fallback to boto for auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ docker run --rm --name example-presence -e AWS_ACCESS_KEY=AKIAIBC5MW3ONCW6J2XQ -
 * `AWS_REGION` ... The AWS region that your load balancer is located in
 * `ELB_NAME` ... The exact name of your load balancer
 
+You can omit the AWS_ACCESS_KEY and AWS_SECRET_KEY variables and fallback to an instance IAM role for authentication.
+
 ### Via Fleet
 
 Usually you'll want to manage the lifecycle of your presence service using

--- a/elb-presence
+++ b/elb-presence
@@ -18,7 +18,7 @@ parser.add_argument('--access-key', metavar='<ACCESS>', default=os.environ.get('
 parser.add_argument('--secret-key', metavar='<SECRET>', default=os.environ.get('AWS_SECRET_KEY'))
 args = parser.parse_args()
 
-if args.access_key and args.access_key:
+if args.access_key and args.secret_key:
     conn = boto.ec2.elb.connect_to_region(args.region,
                                           aws_access_key_id=args.access_key,
                                           aws_secret_access_key=args.secret_key)

--- a/elb-presence
+++ b/elb-presence
@@ -18,9 +18,12 @@ parser.add_argument('--access-key', metavar='<ACCESS>', default=os.environ.get('
 parser.add_argument('--secret-key', metavar='<SECRET>', default=os.environ.get('AWS_SECRET_KEY'))
 args = parser.parse_args()
 
-conn = boto.ec2.elb.connect_to_region(args.region,
-                                      aws_access_key_id=args.access_key,
-                                      aws_secret_access_key=args.secret_key)
+if args.access_key and args.access_key:
+    conn = boto.ec2.elb.connect_to_region(args.region,
+                                          aws_access_key_id=args.access_key,
+                                          aws_secret_access_key=args.secret_key)
+else:
+    conn = boto.ec2.elb.connect_to_region(args.region)
 
 instance = urllib2.urlopen('http://169.254.169.254/latest/meta-data/instance-id').read()
 


### PR DESCRIPTION
I wanted to the script to authenticate using IAM roles on the EC2 instances, rather than manually creating and submitting credentials whenever I run the Docker container. In order to do this I've added a condition to check whether the input has been omitted and if so it will fall back to the connect_to_region call without the arguments - Boto does the rest. 
